### PR TITLE
Try to fix psd section of example 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,22 @@ lc_simu = simulate_flux_points(
 )
 
 # 3. Fit the PSD of the simulated light curve
-# The psd_fit function can take the FluxPoints object directly as input
+sim_flux = lc_simu.flux.data.flatten()
+sim_time_nodes = (lc_simu.geom.axes["time"].edges_min + lc_simu.geom.axes["time"].edges_max)/2
+ls = LombScargle(sim_time_nodes, sim_flux)
+freq, power = ls.autopower(nyquist_factor=1, samples_per_peak=1, normalization="psd")
+
 index_fit, index_err = psd_fit(
-    lightcurve=lc_simu,
+    freq,
+    power,
+    times,
     psd=psd_model,
-    psd_initial={"index": -1.0}, # Initial guess for the fit
-    simulator="MTK", # Use MTK for unevenly sampled data
-    nsims=100, # Use more sims for a real case
-    nexp=10,   # Use more experiments for a real case
+    mean=flux.mean(),
+    std=flux.std(),
+    psd_initial={"index": -1.0},  # Initial guess for the fit
+    simulator="MTK",  # Use MTK for unevenly sampled data
+    nsims=100,  # Use more sims for a real case
+    nexp=10,  # Use more experiments for a real case
 )
 
 print(f"Injected PSD index: {psd_params['index']}")


### PR DESCRIPTION
I tried to fix the `psd_fit` section of example 3, basically just adapting to use the form of call shown in example 2, hopefully this is correct.  

Unfortunately the `TimeMapAxes` that comes out of `simulate_flux_points` claims it is not contiguous, so the way to get the time points is a bit dirty.